### PR TITLE
Add low-pass filter

### DIFF
--- a/include/SQuIDS/SUNalg.h
+++ b/include/SQuIDS/SUNalg.h
@@ -513,6 +513,34 @@ public:
     double range = t_end - t_start;
 #include "SU_inc/PreEvolutionSelectAvgRange.txt"
   }
+  
+  ///\brief Compute low-pass filter for pre-computed sine and cosine evaluations
+  ///
+  /// This function applies a low-pass filter to the pre-evolution buffer computed by
+  /// PrepareEvolve to filter out high frequencies. This is distinct from the already
+  /// existing averaging mechanism because this function filters the frequency, not the
+  /// number of rotations (i.e. frequency times time). This allows this function to be
+  /// used both during evaluation of probabilities from the evolved state as well as
+  /// during the integration of the interaction state equation.
+  ///\param buffer  The buffer with evaluated sine/cosine values from PrepareEvolve.
+  ///\param cutoff  Cut-off frequency of the filter. Sine and cosine evaluations 
+  ///               with input frequencies higher than this will be set to zero
+  ///\param scale   Distance in frequency between cut-off and pass-through. A value of 
+  ///               greater than zero allows for a gradual transition to cut-off, rather
+  ///               than applying a hard step function.
+  void LowPassFilter(double* buffer, double cutoff, double scale) const{
+    auto& suv1=*this;
+    size_t offset=GetEvolveBufferSize()/2;
+    double* CX=buffer;
+    double* SX=buffer+offset;
+    double freq;
+    int i;
+    // first writing frequencies into buffer, then converting into scale factors
+    // in-place
+#include "SU_inc/LowPassFilterSelect.txt"    
+  }
+  
+  
   ///\brief Compute the time evolution of the SU_vector
   ///
   ///\param buffer A buffer which has been filled by a previous call to

--- a/include/SQuIDS/SUNalg.h
+++ b/include/SQuIDS/SUNalg.h
@@ -521,7 +521,8 @@ public:
   /// existing averaging mechanism because this function filters the frequency, not the
   /// number of rotations (i.e. frequency times time). This allows this function to be
   /// used both during evaluation of probabilities from the evolved state as well as
-  /// during the integration of the interaction state equation.
+  /// during the integration of the interaction state equation. A linear ramp can be
+  /// used to soften the cut-off of the filter.
   ///\param buffer  The buffer with evaluated sine/cosine values from PrepareEvolve.
   ///\param cutoff  Cut-off frequency of the filter. Sine and cosine evaluations 
   ///               with input frequencies higher than this will be set to zero
@@ -535,8 +536,6 @@ public:
     double* SX=buffer+offset;
     double freq;
     int i;
-    // first writing frequencies into buffer, then converting into scale factors
-    // in-place
 #include "SU_inc/LowPassFilterSelect.txt"    
   }
   

--- a/include/SQuIDS/SU_inc/ApplyLowPassFilter.txt
+++ b/include/SQuIDS/SU_inc/ApplyLowPassFilter.txt
@@ -20,7 +20,7 @@
  *      Christopher Weaver (University of Wisconsin Madison)                   *
  *         cweaver@icecube.wisc.edu                                            *
  *      Alexander Trettin (DESY)                                               *
- *         atretin@icecube.wisc.edu                                            *
+ *         atrettin@icecube.wisc.edu                                           *
  ******************************************************************************/
  // greater than cutoff implies setting to zero
  if (fabs(freq) > fabs(cutoff)){

--- a/include/SQuIDS/SU_inc/ApplyLowPassFilter.txt
+++ b/include/SQuIDS/SU_inc/ApplyLowPassFilter.txt
@@ -1,0 +1,35 @@
+ /******************************************************************************
+ *    This program is free software: you can redistribute it and/or modify     *
+ *   it under the terms of the GNU General Public License as published by      *
+ *   the Free Software Foundation, either version 3 of the License, or         *
+ *   (at your option) any later version.                                       *
+ *                                                                             *
+ *   This program is distributed in the hope that it will be useful,           *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ *   GNU General Public License for more details.                              *
+ *                                                                             *
+ *   You should have received a copy of the GNU General Public License         *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                             *
+ *   Authors:                                                                  *
+ *      Carlos Arguelles (University of Wisconsin Madison)                     *
+ *         carguelles@icecube.wisc.edu                                         *
+ *      Jordi Salvado (University of Wisconsin Madison)                        *
+ *         jsalvado@icecube.wisc.edu                                           *
+ *      Christopher Weaver (University of Wisconsin Madison)                   *
+ *         cweaver@icecube.wisc.edu                                            *
+ *      Alexander Trettin (DESY)                                               *
+ *         atretin@icecube.wisc.edu                                            *
+ ******************************************************************************/
+ // greater than cutoff implies setting to zero
+ if (fabs(freq) > fabs(cutoff)){
+    SX[i] = 0;
+    CX[i] = 0;
+ // If we are below the cutoff, but above the threshold where we begin to apply the 
+ // filter gradually, we do that.
+ }else if(fabs(freq) > fabs(cutoff) - fabs(scale)){
+    SX[i] *= (fabs(cutoff) - fabs(freq))/fabs(scale);
+    CX[i] *= (fabs(cutoff) - fabs(freq))/fabs(scale);
+ }
+ // if neither of the cases above applied, we do nothing

--- a/include/SQuIDS/SU_inc/LowPassFilterSU2.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSU2.txt
@@ -1,0 +1,27 @@
+ /******************************************************************************
+ *    This program is free software: you can redistribute it and/or modify     *
+ *   it under the terms of the GNU General Public License as published by      *
+ *   the Free Software Foundation, either version 3 of the License, or         *
+ *   (at your option) any later version.                                       *
+ *                                                                             *
+ *   This program is distributed in the hope that it will be useful,           *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ *   GNU General Public License for more details.                              *
+ *                                                                             *
+ *   You should have received a copy of the GNU General Public License         *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                             *
+ *   Authors:                                                                  *
+ *      Carlos Arguelles (University of Wisconsin Madison)                     *
+ *         carguelles@icecube.wisc.edu                                         *
+ *      Jordi Salvado (University of Wisconsin Madison)                        *
+ *         jsalvado@icecube.wisc.edu                                           *
+ *      Christopher Weaver (University of Wisconsin Madison)                   *
+ *         cweaver@icecube.wisc.edu                                            *
+ *      Alexander Trettin (DESY)                                               *
+ *         atretin@icecube.wisc.edu                                            *
+ ******************************************************************************/
+freq=2*suv1.components[3];
+i = 0;
+#include "ApplyLowPassFilter.txt"

--- a/include/SQuIDS/SU_inc/LowPassFilterSU2.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSU2.txt
@@ -20,7 +20,7 @@
  *      Christopher Weaver (University of Wisconsin Madison)                   *
  *         cweaver@icecube.wisc.edu                                            *
  *      Alexander Trettin (DESY)                                               *
- *         atretin@icecube.wisc.edu                                            *
+ *         atrettin@icecube.wisc.edu                                           *
  ******************************************************************************/
 freq=2*suv1.components[3];
 i = 0;

--- a/include/SQuIDS/SU_inc/LowPassFilterSU3.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSU3.txt
@@ -1,0 +1,33 @@
+ /******************************************************************************
+ *    This program is free software: you can redistribute it and/or modify     *
+ *   it under the terms of the GNU General Public License as published by      *
+ *   the Free Software Foundation, either version 3 of the License, or         *
+ *   (at your option) any later version.                                       *
+ *                                                                             *
+ *   This program is distributed in the hope that it will be useful,           *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ *   GNU General Public License for more details.                              *
+ *                                                                             *
+ *   You should have received a copy of the GNU General Public License         *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                             *
+ *   Authors:                                                                  *
+ *      Carlos Arguelles (University of Wisconsin Madison)                     *
+ *         carguelles@icecube.wisc.edu                                         *
+ *      Jordi Salvado (University of Wisconsin Madison)                        *
+ *         jsalvado@icecube.wisc.edu                                           *
+ *      Christopher Weaver (University of Wisconsin Madison)                   *
+ *         cweaver@icecube.wisc.edu                                            *
+ *      Alexander Trettin (DESY)                                               *
+ *         atretin@icecube.wisc.edu                                            *
+ ******************************************************************************/
+freq=2*suv1.components[4];
+i=0;
+#include "ApplyLowPassFilter.txt"
+freq=(suv1.components[4] + sqrt(3)*suv1.components[8]);
+i=1;
+#include "ApplyLowPassFilter.txt"
+freq=(suv1.components[4] - sqrt(3)*suv1.components[8]);
+i=2;
+#include "ApplyLowPassFilter.txt"

--- a/include/SQuIDS/SU_inc/LowPassFilterSU3.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSU3.txt
@@ -20,7 +20,7 @@
  *      Christopher Weaver (University of Wisconsin Madison)                   *
  *         cweaver@icecube.wisc.edu                                            *
  *      Alexander Trettin (DESY)                                               *
- *         atretin@icecube.wisc.edu                                            *
+ *         atrettin@icecube.wisc.edu                                           *
  ******************************************************************************/
 freq=2*suv1.components[4];
 i=0;

--- a/include/SQuIDS/SU_inc/LowPassFilterSU4.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSU4.txt
@@ -20,7 +20,7 @@
  *      Christopher Weaver (University of Wisconsin Madison)                   *
  *         cweaver@icecube.wisc.edu                                            *
  *      Alexander Trettin (DESY)                                               *
- *         atretin@icecube.wisc.edu                                            *
+ *         atrettin@icecube.wisc.edu                                           *
  ******************************************************************************/
 freq=2*suv1.components[5];
 i=0;

--- a/include/SQuIDS/SU_inc/LowPassFilterSU4.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSU4.txt
@@ -1,0 +1,42 @@
+ /******************************************************************************
+ *    This program is free software: you can redistribute it and/or modify     *
+ *   it under the terms of the GNU General Public License as published by      *
+ *   the Free Software Foundation, either version 3 of the License, or         *
+ *   (at your option) any later version.                                       *
+ *                                                                             *
+ *   This program is distributed in the hope that it will be useful,           *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ *   GNU General Public License for more details.                              *
+ *                                                                             *
+ *   You should have received a copy of the GNU General Public License         *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                             *
+ *   Authors:                                                                  *
+ *      Carlos Arguelles (University of Wisconsin Madison)                     *
+ *         carguelles@icecube.wisc.edu                                         *
+ *      Jordi Salvado (University of Wisconsin Madison)                        *
+ *         jsalvado@icecube.wisc.edu                                           *
+ *      Christopher Weaver (University of Wisconsin Madison)                   *
+ *         cweaver@icecube.wisc.edu                                            *
+ *      Alexander Trettin (DESY)                                               *
+ *         atretin@icecube.wisc.edu                                            *
+ ******************************************************************************/
+freq=2*suv1.components[5];
+i=0;
+#include "ApplyLowPassFilter.txt"
+freq=(suv1.components[5] + sqrt(3)*suv1.components[10]);
+i=1;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[5] + ((suv1.components[10] + 2*sqrt(2)*suv1.components[15]))/sqrt(3);
+i=2;
+#include "ApplyLowPassFilter.txt"
+freq=(suv1.components[5] - sqrt(3)*suv1.components[10]);
+i=3;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[5] - ((suv1.components[10] + 2*sqrt(2)*suv1.components[15]))/sqrt(3);
+i=4;
+#include "ApplyLowPassFilter.txt"
+freq=(2*(suv1.components[10] - sqrt(2)*suv1.components[15]))/sqrt(3);
+i=5;
+#include "ApplyLowPassFilter.txt"

--- a/include/SQuIDS/SU_inc/LowPassFilterSU5.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSU5.txt
@@ -20,7 +20,7 @@
  *      Christopher Weaver (University of Wisconsin Madison)                   *
  *         cweaver@icecube.wisc.edu                                            *
  *      Alexander Trettin (DESY)                                               *
- *         atretin@icecube.wisc.edu                                            *
+ *         atrettin@icecube.wisc.edu                                           *
  ******************************************************************************/
 freq=2*suv1.components[6];
 i=0;

--- a/include/SQuIDS/SU_inc/LowPassFilterSU5.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSU5.txt
@@ -1,0 +1,54 @@
+ /******************************************************************************
+ *    This program is free software: you can redistribute it and/or modify     *
+ *   it under the terms of the GNU General Public License as published by      *
+ *   the Free Software Foundation, either version 3 of the License, or         *
+ *   (at your option) any later version.                                       *
+ *                                                                             *
+ *   This program is distributed in the hope that it will be useful,           *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ *   GNU General Public License for more details.                              *
+ *                                                                             *
+ *   You should have received a copy of the GNU General Public License         *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                             *
+ *   Authors:                                                                  *
+ *      Carlos Arguelles (University of Wisconsin Madison)                     *
+ *         carguelles@icecube.wisc.edu                                         *
+ *      Jordi Salvado (University of Wisconsin Madison)                        *
+ *         jsalvado@icecube.wisc.edu                                           *
+ *      Christopher Weaver (University of Wisconsin Madison)                   *
+ *         cweaver@icecube.wisc.edu                                            *
+ *      Alexander Trettin (DESY)                                               *
+ *         atretin@icecube.wisc.edu                                            *
+ ******************************************************************************/
+freq=2*suv1.components[6];
+i=0;
+#include "ApplyLowPassFilter.txt"
+freq=(suv1.components[6] + sqrt(3)*suv1.components[12]);
+i=1;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[6] + ((suv1.components[12] + 2*sqrt(2)*suv1.components[18]))/sqrt(3);
+i=2;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[6] + (suv1.components[12])/sqrt(3) + (suv1.components[18])/sqrt(6) + sqrt(2.5)*suv1.components[24];
+i=3;
+#include "ApplyLowPassFilter.txt"
+freq=(suv1.components[6] - sqrt(3)*suv1.components[12]);
+i=4;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[6] - ((suv1.components[12] + 2*sqrt(2)*suv1.components[18]))/sqrt(3);
+i=5;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[6] - ((2*sqrt(3)*suv1.components[12] + sqrt(6)*suv1.components[18] + 3*sqrt(10)*suv1.components[24]))/6.;
+i=6;
+#include "ApplyLowPassFilter.txt"
+freq=(2*(suv1.components[12] - sqrt(2)*suv1.components[18]))/sqrt(3);
+i=7;
+#include "ApplyLowPassFilter.txt"
+freq=((4*sqrt(3)*suv1.components[12] - sqrt(6)*suv1.components[18] - 3*sqrt(10)*suv1.components[24]))/6.;
+i=8;
+#include "ApplyLowPassFilter.txt"
+freq=sqrt(1.5)*suv1.components[18] - sqrt(2.5)*suv1.components[24];
+i=9;
+#include "ApplyLowPassFilter.txt"

--- a/include/SQuIDS/SU_inc/LowPassFilterSU6.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSU6.txt
@@ -1,0 +1,69 @@
+ /******************************************************************************
+ *    This program is free software: you can redistribute it and/or modify     *
+ *   it under the terms of the GNU General Public License as published by      *
+ *   the Free Software Foundation, either version 3 of the License, or         *
+ *   (at your option) any later version.                                       *
+ *                                                                             *
+ *   This program is distributed in the hope that it will be useful,           *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ *   GNU General Public License for more details.                              *
+ *                                                                             *
+ *   You should have received a copy of the GNU General Public License         *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                             *
+ *   Authors:                                                                  *
+ *      Carlos Arguelles (University of Wisconsin Madison)                     *
+ *         carguelles@icecube.wisc.edu                                         *
+ *      Jordi Salvado (University of Wisconsin Madison)                        *
+ *         jsalvado@icecube.wisc.edu                                           *
+ *      Christopher Weaver (University of Wisconsin Madison)                   *
+ *         cweaver@icecube.wisc.edu                                            *
+ *      Alexander Trettin (DESY)                                               *
+ *         atretin@icecube.wisc.edu                                            *
+ ******************************************************************************/
+freq=2*suv1.components[7];
+i=0;
+#include "ApplyLowPassFilter.txt"
+freq=(suv1.components[7] + sqrt(3)*suv1.components[14]);
+i=1;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[7] + ((suv1.components[14] + 2*sqrt(2)*suv1.components[21]))/sqrt(3);
+i=2;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[7] + (suv1.components[14])/sqrt(3) + (suv1.components[21])/sqrt(6) + sqrt(2.5)*suv1.components[28];
+i=3;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[7] + (suv1.components[14])/sqrt(3) + (suv1.components[21])/sqrt(6) + (suv1.components[28])/sqrt(10) + 2*sqrt(0.6)*suv1.components[35];
+i=4;
+#include "ApplyLowPassFilter.txt"
+freq=(suv1.components[7] - sqrt(3)*suv1.components[14]);
+i=5;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[7] - ((suv1.components[14] + 2*sqrt(2)*suv1.components[21]))/sqrt(3);
+i=6;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[7] - ((2*sqrt(3)*suv1.components[14] + sqrt(6)*suv1.components[21] + 3*sqrt(10)*suv1.components[28]))/6.;
+i=7;
+#include "ApplyLowPassFilter.txt"
+freq=suv1.components[7] - ((10*sqrt(3)*suv1.components[14] + 5*sqrt(6)*suv1.components[21] + 3*sqrt(10)*suv1.components[28] + 12*sqrt(15)*suv1.components[35]))/30.;
+i=8;
+#include "ApplyLowPassFilter.txt"
+freq=(2*(suv1.components[14] - sqrt(2)*suv1.components[21]))/sqrt(3);
+i=9;
+#include "ApplyLowPassFilter.txt"
+freq=((4*sqrt(3)*suv1.components[14] - sqrt(6)*suv1.components[21] - 3*sqrt(10)*suv1.components[28]))/6.;
+i=10;
+#include "ApplyLowPassFilter.txt"
+freq=(2*suv1.components[14])/sqrt(3) - (suv1.components[21])/sqrt(6) - (suv1.components[28])/sqrt(10) - 2*sqrt(0.6)*suv1.components[35];
+i=11;
+#include "ApplyLowPassFilter.txt"
+freq=sqrt(1.5)*suv1.components[21] - sqrt(2.5)*suv1.components[28];
+i=12;
+#include "ApplyLowPassFilter.txt"
+freq=sqrt(1.5)*suv1.components[21] - (suv1.components[28])/sqrt(10) - 2*sqrt(0.6)*suv1.components[35];
+i=13;
+#include "ApplyLowPassFilter.txt"
+freq=2*sqrt(0.4)*suv1.components[28] - 2*sqrt(0.6)*suv1.components[35];
+i=14;
+#include "ApplyLowPassFilter.txt"

--- a/include/SQuIDS/SU_inc/LowPassFilterSU6.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSU6.txt
@@ -20,7 +20,7 @@
  *      Christopher Weaver (University of Wisconsin Madison)                   *
  *         cweaver@icecube.wisc.edu                                            *
  *      Alexander Trettin (DESY)                                               *
- *         atretin@icecube.wisc.edu                                            *
+ *         atrettin@icecube.wisc.edu                                           *
  ******************************************************************************/
 freq=2*suv1.components[7];
 i=0;

--- a/include/SQuIDS/SU_inc/LowPassFilterSelect.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSelect.txt
@@ -19,6 +19,8 @@
  *         jsalvado@icecube.wisc.edu                                           *
  *      Christopher Weaver (University of Wisconsin Madison)                   * 
  *         cweaver@icecube.wisc.edu                                            *
+ *      Alexander Trettin (DESY)                                               *
+ *         atrettin@icecube.wisc.edu                                           *
  ******************************************************************************/
 switch (dim){
   case 2: 

--- a/include/SQuIDS/SU_inc/LowPassFilterSelect.txt
+++ b/include/SQuIDS/SU_inc/LowPassFilterSelect.txt
@@ -1,0 +1,41 @@
+ /******************************************************************************
+ *    This program is free software: you can redistribute it and/or modify     *
+ *   it under the terms of the GNU General Public License as published by      *
+ *   the Free Software Foundation, either version 3 of the License, or         *
+ *   (at your option) any later version.                                       *
+ *                                                                             *
+ *   This program is distributed in the hope that it will be useful,           *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ *   GNU General Public License for more details.                              *
+ *                                                                             *
+ *   You should have received a copy of the GNU General Public License         *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                             *   
+ *   Authors:                                                                  *
+ *      Carlos Arguelles (University of Wisconsin Madison)                     * 
+ *         carguelles@icecube.wisc.edu                                         *
+ *      Jordi Salvado (University of Wisconsin Madison)                        *
+ *         jsalvado@icecube.wisc.edu                                           *
+ *      Christopher Weaver (University of Wisconsin Madison)                   * 
+ *         cweaver@icecube.wisc.edu                                            *
+ ******************************************************************************/
+switch (dim){
+  case 2: 
+    #include "LowPassFilterSU2.txt"
+    break;
+  case 3: 
+    #include "LowPassFilterSU3.txt"
+    break;
+  case 4: 
+    #include "LowPassFilterSU4.txt"
+    break;
+  case 5: 
+    #include "LowPassFilterSU5.txt"
+    break;
+  case 6: 
+    #include "LowPassFilterSU6.txt"
+    break;
+  default:
+    throw std::runtime_error("SU_vector Evolution Error: Only dimensions up to " SQUIDS_MAX_HILBERT_DIM_STR " are supported");
+}


### PR DESCRIPTION
This PR adds a low-pass filter to the SU(N) algebra module of SQuIDS. This filter is distinct from the already existing averaging feature in two ways:

1. It lives in a separate function and can be called on an already computed pre-evolve buffer. This makes it very flexible as it can be applied both for projecting out probabilities and during numerical integration.
2. It is applied to the frequency, not the number of rotations (i.e. to f rather than f*t). This makes it valid to apply it during the integration step. It has only an energy dependency, not a time dependency.

One can also pass a `scale` option to apply a linear ramp to the filter to soften the cut-off and to smooth transition between the filtered and non-filtered energy regions. 